### PR TITLE
Warn when a cache miss leads to graphic glitches

### DIFF
--- a/apng-view/src/main/java/com/github/sahasbhop/apngview/ApngDrawable.java
+++ b/apng-view/src/main/java/com/github/sahasbhop/apngview/ApngDrawable.java
@@ -364,6 +364,9 @@ public class ApngDrawable extends Drawable implements Animatable, Runnable {
 
                         if (tempDisposeOp == PngChunkFCTL.APNG_DISPOSE_OP_NONE) {
                             bitmap = getCacheBitmap(i);
+							if (bitmap == null) {
+								FLog.w("Can't retrieve previous APNG_DISPOSE_OP_NONE frame: please try to increase memory cache size!");
+							}
 
                         } else if (tempDisposeOp == PngChunkFCTL.APNG_DISPOSE_OP_BACKGROUND) {
                             if (enableVerboseLog) FLog.v("Create a new bitmap");


### PR DESCRIPTION
APNG_DISPOSE_OP_PREVIOUS frames need to retrieve the previous APNG_DISPOSE_OP_NONE frame from cache to correctly dispose the current chunk.
Warn the user if a cache miss occurs and suggest a solution.
